### PR TITLE
API setup

### DIFF
--- a/app/controllers/api/mood_logs_controller.rb
+++ b/app/controllers/api/mood_logs_controller.rb
@@ -1,4 +1,4 @@
-class MoodLogsController < ApplicationController
+class Api::MoodLogsController < ApplicationController
   before_action :set_mood_log, only: %i[ show update destroy ]
 
   # GET /mood_logs
@@ -18,7 +18,7 @@ class MoodLogsController < ApplicationController
     @mood_log = MoodLog.new(mood_log_params)
 
     if @mood_log.save
-      render json: @mood_log, status: :created, location: @mood_log
+      render json: @mood_log, status: :created, location: api_mood_log_url(@mood_log)
     else
       render json: @mood_log.errors, status: :unprocessable_entity
     end
@@ -46,6 +46,6 @@ class MoodLogsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def mood_log_params
-      params.require(:mood_log).permit(:notes)
+      params.require(:mood_log).permit(:notes, scale_item_ids: [])
     end
 end

--- a/app/controllers/api/moodscales_controller.rb
+++ b/app/controllers/api/moodscales_controller.rb
@@ -1,4 +1,4 @@
-class MoodscalesController < ApplicationController
+class Api::MoodscalesController < ApplicationController
   before_action :set_moodscale, only: %i[ show update destroy ]
 
   # GET /moodscales
@@ -18,7 +18,7 @@ class MoodscalesController < ApplicationController
     @moodscale = Moodscale.new(moodscale_params)
 
     if @moodscale.save
-      render json: @moodscale, status: :created, location: @moodscale
+      render json: @moodscale, status: :created, location: api_moodscale_url(@moodscale)
     else
       render json: @moodscale.errors, status: :unprocessable_entity
     end
@@ -46,6 +46,6 @@ class MoodscalesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def moodscale_params
-      params.require(:moodscale).permit(:name, :scale_type, :scale_items_attributes)
+      params.require(:moodscale).permit(:name, :scale_type, scale_items_attributes: [:index, :alias])
     end
 end

--- a/app/controllers/api/scale_items_controller.rb
+++ b/app/controllers/api/scale_items_controller.rb
@@ -1,4 +1,4 @@
-class ScaleItemsController < ApplicationController
+class Api::ScaleItemsController < ApplicationController
   before_action :set_scale_item, only: %i[ show update destroy ]
 
   # GET /scale_items

--- a/app/controllers/moodscales_controller.rb
+++ b/app/controllers/moodscales_controller.rb
@@ -46,6 +46,6 @@ class MoodscalesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def moodscale_params
-      params.require(:moodscale).permit(:name, :scale_type)
+      params.require(:moodscale).permit(:name, :scale_type, :scale_items_attributes)
     end
 end

--- a/app/controllers/moodscales_controller.rb
+++ b/app/controllers/moodscales_controller.rb
@@ -46,6 +46,6 @@ class MoodscalesController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def moodscale_params
-      params.require(:moodscale).permit(:name, :type)
+      params.require(:moodscale).permit(:name, :scale_type)
     end
 end

--- a/app/models/moodscale.rb
+++ b/app/models/moodscale.rb
@@ -2,4 +2,6 @@ class Moodscale < ApplicationRecord
     has_many :scale_items, dependent: :destroy
 
     validates :name, :scale_type, presence: true
+
+    accepts_nested_attributes_for :scale_items
 end

--- a/app/models/moodscale.rb
+++ b/app/models/moodscale.rb
@@ -1,5 +1,5 @@
 class Moodscale < ApplicationRecord
-    has_many :scale_items, dependent :destroy
-    
-    validates :name, :type, presence: true
+    has_many :scale_items, dependent: :destroy
+
+    validates :name, :scale_type, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
-  resources :mood_logs
-  resources :scale_items
-  resources :moodscales
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
+  namespace :api do
+    resources :mood_logs
+    resources :scale_items
+    resources :moodscales
+  end
   # Defines the root path route ("/")
   # root "articles#index"
 end

--- a/db/migrate/20230602135001_create_moodscales.rb
+++ b/db/migrate/20230602135001_create_moodscales.rb
@@ -2,7 +2,7 @@ class CreateMoodscales < ActiveRecord::Migration[7.0]
   def change
     create_table :moodscales do |t|
       t.string :name, null:false
-      t.string :type, null:false
+      t.string :scale_type, null:false
 
       t.timestamps
     end

--- a/db/migrate/20230602145350_create_join_table_mood_logs_scale_item.rb
+++ b/db/migrate/20230602145350_create_join_table_mood_logs_scale_item.rb
@@ -1,8 +1,8 @@
 class CreateJoinTableMoodLogsScaleItem < ActiveRecord::Migration[7.0]
   def change
     create_table :mood_logs_scale_items, id: false do |t|
-      t.references :mood_logs, null: false, foreign_key: true
-      t.references :scale_items, null:false, foreign_key: true
+      t.references :mood_log, null: false, foreign_key: true
+      t.references :scale_item, null:false, foreign_key: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,10 +21,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_02_145350) do
   end
 
   create_table "mood_logs_scale_items", id: false, force: :cascade do |t|
-    t.bigint "mood_logs_id", null: false
-    t.bigint "scale_items_id", null: false
-    t.index ["mood_logs_id"], name: "index_mood_logs_scale_items_on_mood_logs_id"
-    t.index ["scale_items_id"], name: "index_mood_logs_scale_items_on_scale_items_id"
+    t.bigint "mood_log_id", null: false
+    t.bigint "scale_item_id", null: false
+    t.index ["mood_log_id"], name: "index_mood_logs_scale_items_on_mood_log_id"
+    t.index ["scale_item_id"], name: "index_mood_logs_scale_items_on_scale_item_id"
   end
 
   create_table "moodscales", force: :cascade do |t|
@@ -43,7 +43,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_02_145350) do
     t.index ["moodscale_id"], name: "index_scale_items_on_moodscale_id"
   end
 
-  add_foreign_key "mood_logs_scale_items", "mood_logs", column: "mood_logs_id"
-  add_foreign_key "mood_logs_scale_items", "scale_items", column: "scale_items_id"
+  add_foreign_key "mood_logs_scale_items", "mood_logs"
+  add_foreign_key "mood_logs_scale_items", "scale_items"
   add_foreign_key "scale_items", "moodscales"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,7 +29,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_02_145350) do
 
   create_table "moodscales", force: :cascade do |t|
     t.string "name", null: false
-    t.string "type", null: false
+    t.string "scale_type", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
Basic get, create, and delete logic now works for all initial API routes. Controllers were moved to the API folder and updated so that the /api route could be used. Params were also put in place so that the required creations and associations with scale_items could be made through moodscales and mood_logs.

All existing records will be considered immutable so actions such as update are to be removed and modified later when soft deletion logic is in place.